### PR TITLE
[Platform] Connect AP even if the authmode is not clear

### DIFF
--- a/src/platform/senscomm/scm1612s/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/senscomm/scm1612s/ConnectivityManagerImpl_WIFI.cpp
@@ -195,6 +195,7 @@ void ConnectivityManagerImpl::_OnWiFiPlatformEvent(const ChipDeviceEvent * event
             ChangeWiFiStationState(kWiFiStationState_Connecting_Succeeded);
         }
         scm_wifi_dhcp_start();
+        NetworkCommissioning::WiseWiFiDriver::GetInstance().UpdateWiFiAuthmode();
         DriveStationState();
         break;
     case SYSTEM_EVENT_STA_DISCONNECTED:
@@ -244,6 +245,11 @@ void ConnectivityManagerImpl::_OnWiFiPlatformEvent(const ChipDeviceEvent * event
         ip6addr_ntoa_r(&got_ip.ip6_info.ip, addrStr, sizeof(addrStr));
 
         UpdateInternetConnectivityState(hadIPv4Conn, true, reinterpret_cast<const uint8_t *>(addrStr));
+    }
+        break;
+    case SYSTEM_EVENT_STA_NO_NETWORK:
+    {
+        scm_wifi_sta_connect_advance();
     }
         break;
     default:

--- a/src/platform/senscomm/scm1612s/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/senscomm/scm1612s/NetworkCommissioningWiFiDriver.h
@@ -120,6 +120,7 @@ public:
 
     void OnConnectWiFiNetwork();
     void OnScanWiFiNetworkDone();
+    void UpdateWiFiAuthmode();
     CHIP_ERROR SetLastDisconnectReason(const ChipDeviceEvent * event);
     static WiseWiFiDriver & GetInstance()
     {


### PR DESCRIPTION
Changes:
- Support WPA2/WPA3 AP connection

Fixes:

Issues:
- Senscomm/wise/issues/2859

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

