### PR TITLE
[TH] Fix for TC-CNET-4.4 & Add ACL.S.A0001 for  TC-ACL-2.x

### DIFF
--- a/examples/lighting-app/senscomm/scm1612s/data_model/lighting-app.matter
+++ b/examples/lighting-app/senscomm/scm1612s/data_model/lighting-app.matter
@@ -1211,6 +1211,7 @@ endpoint 0 {
     emits event AccessControlEntryChanged;
     emits event AccessControlExtensionChanged;
     callback attribute acl;
+    callback attribute extension;
     callback attribute subjectsPerAccessControlEntry;
     callback attribute targetsPerAccessControlEntry;
     callback attribute accessControlEntriesPerFabric;

--- a/examples/lighting-app/senscomm/scm1612s/data_model/lighting-app.zap
+++ b/examples/lighting-app/senscomm/scm1612s/data_model/lighting-app.zap
@@ -191,6 +191,22 @@
               "reportableChange": 0
             },
             {
+              "name": "Extension",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "SubjectsPerAccessControlEntry",
               "code": 2,
               "mfgCode": null,

--- a/src/platform/senscomm/scm1612s/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/senscomm/scm1612s/NetworkCommissioningWiFiDriver.cpp
@@ -366,7 +366,7 @@ void WiseWiFiDriver::OnScanWiFiNetworkDone()
     // Since this is the dynamic memory allocation, restrict it to a configured limit
     ap_number = std::min(static_cast<uint16_t>(CHIP_DEVICE_CONFIG_MAX_SCAN_NETWORKS_RESULTS), ap_number);
 
-    std::unique_ptr<scm_wifi_ap_info[]> ap_buffer_ptr(new scm_wifi_ap_info[ap_number]);
+    std::unique_ptr<scm_wifi_ap_info[]> ap_buffer_ptr(new scm_wifi_ap_info[ap_number]());
     if (ap_buffer_ptr == NULL)
     {
         ChipLogError(DeviceLayer, "can't malloc memory for ap_list_buffer");
@@ -377,9 +377,9 @@ void WiseWiFiDriver::OnScanWiFiNetworkDone()
     scm_wifi_ap_info * ap_list_buffer = ap_buffer_ptr.get();
     if (scm_wifi_sta_scan_results(ap_list_buffer, &num, ap_number) == WISE_OK)
     {
-        if (CHIP_NO_ERROR == DeviceLayer::SystemLayer().ScheduleLambda([ap_number, ap_list_buffer]() {
+        if (CHIP_NO_ERROR == DeviceLayer::SystemLayer().ScheduleLambda([num, ap_list_buffer]() {
                 std::unique_ptr<scm_wifi_ap_info[]> auto_free(ap_list_buffer);
-                WiseScanResponseIterator iter(ap_number, ap_list_buffer);
+                WiseScanResponseIterator iter(num, ap_list_buffer);
                 if (GetInstance().mpScanCallback)
                 {
                     GetInstance().mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), &iter);


### PR DESCRIPTION
New features:

Changes:
- Changes for TC-ACL-2.10

Fixs:
- Set WiseScanResponseIterator size to real ap_num instead of max_ap_num.

Issues:
- Resolves Senscomm/wise#2879
- Resolves Senscomm/wise#2891

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

