### PR TITLE
[DAC] Use the factory DAC instead of the test one

### DIFF
--- a/examples/lighting-app/senscomm/scm1612s/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/senscomm/scm1612s/include/CHIPProjectConfig.h
@@ -48,18 +48,18 @@
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
  *
- * 0x1373: MediaTek's Vendor Id.
+ * 0x15FE: Senscomm's Vendor Id.
  * 0xFFF1: Common Test Vendor Id.
  */
-#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
+#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0x15FE
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
  *
- * 0x1000: Genio lighting-app
+ * 0x1612: SCM lighting-app
  * 0x8005: Common test lighting-app
  */
-#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8005
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x1612
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION

--- a/src/platform/senscomm/scm1612s/BUILD.gn
+++ b/src/platform/senscomm/scm1612s/BUILD.gn
@@ -74,6 +74,7 @@ static_library("scm1612s") {
   deps = [
       "${chip_root}/src/lib/dnssd:platform_header",
       "${chip_root}/src/platform/logging:headers",
+      "${chip_root}/src/credentials:credentials_header",
     ]
 
   # mDNS
@@ -86,6 +87,13 @@ static_library("scm1612s") {
       "ConnectivityManagerImpl_WIFI.cpp",
       "NetworkCommissioningWiFiDriver.cpp",
       "NetworkCommissioningWiFiDriver.h",
+    ]
+  }
+
+  if (true) {
+    sources += [
+      "FactoryDataProvider.cpp",
+      "FactoryDataProvider.h",
     ]
   }
 }

--- a/src/platform/senscomm/scm1612s/FactoryDataProvider.cpp
+++ b/src/platform/senscomm/scm1612s/FactoryDataProvider.cpp
@@ -1,0 +1,747 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <credentials/CHIPCert.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/Base64.h>
+#include <lib/support/BytesToHex.h>
+#include <lib/support/Span.h>
+
+#include <platform/CHIPDeviceConfig.h>
+
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+#include <matter_factory_data.h>
+#endif
+
+#include "FactoryDataProvider.h"
+
+using namespace chip::app::Clusters::BasicInformation;
+
+namespace chip {
+namespace DeviceLayer {
+
+CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
+{
+    Crypto::P256SerializedKeypair serializedKeypair;
+    ReturnErrorOnFailure(serializedKeypair.SetLength(privateKey.size() + publicKey.size()));
+    memcpy(serializedKeypair.Bytes(), publicKey.data(), publicKey.size());
+    memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
+    return keypair.Deserialize(serializedKeypair);
+}
+
+CHIP_ERROR FactoryDataProvider::Init()
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    if (false == mfd_init())
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+    }
+#endif
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR FactoryDataProvider::GetCertificationDeclaration(MutableByteSpan & outBuffer)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getCd(outBuffer.data(), outBuffer.size());
+    if (len > 0)
+    {
+        outBuffer.reduce_size(len);
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+
+    static const unsigned char kCdForAllExamples[] = {
+        0x30, 0x81, 0xea, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01,
+        0x07, 0x02, 0xa0, 0x81, 0xdc, 0x30, 0x81, 0xd9, 0x02, 0x01, 0x03, 0x31,
+        0x0d, 0x30, 0x0b, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04,
+        0x02, 0x01, 0x30, 0x45, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d,
+        0x01, 0x07, 0x01, 0xa0, 0x38, 0x04, 0x36, 0x15, 0x24, 0x00, 0x01, 0x25,
+        0x01, 0xfe, 0x15, 0x36, 0x02, 0x05, 0x12, 0x16, 0x18, 0x25, 0x03, 0x00,
+        0x01, 0x2c, 0x04, 0x13, 0x63, 0x73, 0x61, 0x32, 0x30, 0x32, 0x35, 0x31,
+        0x5a, 0x42, 0x33, 0x33, 0x30, 0x30, 0x30, 0x31, 0x2d, 0x32, 0x34, 0x24,
+        0x05, 0x00, 0x24, 0x06, 0x00, 0x25, 0x07, 0x76, 0x98, 0x24, 0x08, 0x01,
+        0x18, 0x31, 0x7e, 0x30, 0x7c, 0x02, 0x01, 0x03, 0x80, 0x14, 0x62, 0xfa,
+        0x82, 0x33, 0x59, 0xac, 0xfa, 0xa9, 0x96, 0x3e, 0x1c, 0xfa, 0x14, 0x0a,
+        0xdd, 0xf5, 0x04, 0xf3, 0x71, 0x60, 0x30, 0x0b, 0x06, 0x09, 0x60, 0x86,
+        0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x30, 0x0a, 0x06, 0x08, 0x2a,
+        0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x04, 0x48, 0x30, 0x46, 0x02,
+        0x21, 0x00, 0x8a, 0x5a, 0x25, 0x6c, 0xc0, 0xd3, 0xcc, 0x56, 0x3f, 0xde,
+        0x3c, 0x53, 0x5e, 0xaf, 0xf7, 0x96, 0x54, 0xed, 0x85, 0xa5, 0xec, 0xee,
+        0x4f, 0x6e, 0x91, 0x95, 0x0a, 0x4d, 0xa5, 0x32, 0x37, 0xcf, 0x02, 0x21,
+        0x00, 0xe2, 0x30, 0x45, 0xd7, 0x26, 0x15, 0x59, 0x4f, 0x05, 0x63, 0x52,
+        0x31, 0xfc, 0x57, 0xa3, 0x2c, 0x4b, 0xff, 0x16, 0x40, 0xc9, 0x1d, 0x14,
+        0xdf, 0x5b, 0x6b, 0x5c, 0x28, 0x03, 0x7f, 0x4e, 0xef
+    };
+
+    ReturnErrorOnFailure(CopySpanToMutableSpan(ByteSpan(kCdForAllExamples), outBuffer));
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer)
+{
+    out_firmware_info_buffer.reduce_size(0);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR FactoryDataProvider::GetDeviceAttestationCert(MutableByteSpan & outBuffer)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getDacCert(outBuffer.data(), outBuffer.size());
+    if (len > 0)
+    {
+        outBuffer.reduce_size(len);
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    static const uint8_t Dac_Cert_Array[] = {
+        0x30, 0x82, 0x02, 0x16, 0x30, 0x82, 0x01, 0xbb, 0xa0, 0x03, 0x02, 0x01,
+        0x02, 0x02, 0x14, 0x5f, 0x47, 0x9d, 0x16, 0x75, 0x80, 0x19, 0xd8, 0x6a,
+        0xa2, 0x87, 0x7e, 0xe1, 0xcd, 0xe1, 0xf2, 0x7d, 0x5a, 0x5f, 0x3a, 0x30,
+        0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x30,
+        0x62, 0x31, 0x21, 0x30, 0x1f, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x18,
+        0x53, 0x65, 0x6e, 0x73, 0x63, 0x6f, 0x6d, 0x6d, 0x20, 0x4d, 0x61, 0x74,
+        0x74, 0x65, 0x72, 0x20, 0x54, 0x65, 0x73, 0x74, 0x20, 0x50, 0x41, 0x49,
+        0x31, 0x27, 0x30, 0x25, 0x06, 0x03, 0x55, 0x04, 0x0a, 0x0c, 0x1e, 0x53,
+        0x65, 0x6e, 0x73, 0x63, 0x6f, 0x6d, 0x6d, 0x20, 0x53, 0x65, 0x6d, 0x69,
+        0x63, 0x6f, 0x6e, 0x64, 0x75, 0x63, 0x74, 0x6f, 0x72, 0x20, 0x43, 0x6f,
+        0x2e, 0x2c, 0x4c, 0x54, 0x44, 0x31, 0x14, 0x30, 0x12, 0x06, 0x0a, 0x2b,
+        0x06, 0x01, 0x04, 0x01, 0x82, 0xa2, 0x7c, 0x02, 0x01, 0x0c, 0x04, 0x31,
+        0x35, 0x46, 0x45, 0x30, 0x1e, 0x17, 0x0d, 0x32, 0x35, 0x30, 0x38, 0x32,
+        0x38, 0x30, 0x39, 0x35, 0x39, 0x34, 0x34, 0x5a, 0x17, 0x0d, 0x34, 0x30,
+        0x30, 0x38, 0x32, 0x34, 0x30, 0x39, 0x35, 0x39, 0x34, 0x34, 0x5a, 0x30,
+        0x51, 0x31, 0x23, 0x30, 0x21, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x1a,
+        0x53, 0x43, 0x4d, 0x31, 0x36, 0x31, 0x32, 0x20, 0x4d, 0x61, 0x74, 0x74,
+        0x65, 0x72, 0x20, 0x43, 0x65, 0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61,
+        0x74, 0x65, 0x31, 0x14, 0x30, 0x12, 0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04,
+        0x01, 0x82, 0xa2, 0x7c, 0x02, 0x02, 0x0c, 0x04, 0x31, 0x36, 0x31, 0x32,
+        0x31, 0x14, 0x30, 0x12, 0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82,
+        0xa2, 0x7c, 0x02, 0x01, 0x0c, 0x04, 0x31, 0x35, 0x46, 0x45, 0x30, 0x59,
+        0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06,
+        0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+        0x04, 0x92, 0xa5, 0xbd, 0xc8, 0xf4, 0x30, 0x73, 0x5e, 0x68, 0x83, 0x18,
+        0x2b, 0xe4, 0x27, 0x70, 0x71, 0x39, 0x80, 0xa5, 0xc2, 0x65, 0x39, 0xaf,
+        0x92, 0xe8, 0x69, 0x08, 0x42, 0xd9, 0xde, 0x05, 0x6c, 0x4b, 0x87, 0x52,
+        0x23, 0x32, 0x89, 0x5c, 0xd9, 0xa5, 0x4a, 0xb9, 0xae, 0xdd, 0x65, 0x85,
+        0x05, 0xa3, 0x33, 0x5a, 0xd1, 0xc0, 0xb8, 0x63, 0x93, 0x25, 0x9d, 0x25,
+        0x10, 0x4f, 0xaf, 0x8b, 0x25, 0xa3, 0x60, 0x30, 0x5e, 0x30, 0x0c, 0x06,
+        0x03, 0x55, 0x1d, 0x13, 0x01, 0x01, 0xff, 0x04, 0x02, 0x30, 0x00, 0x30,
+        0x0e, 0x06, 0x03, 0x55, 0x1d, 0x0f, 0x01, 0x01, 0xff, 0x04, 0x04, 0x03,
+        0x02, 0x07, 0x80, 0x30, 0x1d, 0x06, 0x03, 0x55, 0x1d, 0x0e, 0x04, 0x16,
+        0x04, 0x14, 0x77, 0xd5, 0xb7, 0xe9, 0xaf, 0x8d, 0x27, 0x50, 0xd4, 0x39,
+        0x69, 0x1b, 0x83, 0x41, 0x4a, 0xa7, 0x40, 0x64, 0x0b, 0x16, 0x30, 0x1f,
+        0x06, 0x03, 0x55, 0x1d, 0x23, 0x04, 0x18, 0x30, 0x16, 0x80, 0x14, 0x3d,
+        0xdf, 0x69, 0xee, 0x65, 0x11, 0xd2, 0x0f, 0x7d, 0x55, 0x23, 0xb9, 0x9d,
+        0xf8, 0xb2, 0x29, 0x19, 0x50, 0xa8, 0x14, 0x30, 0x0a, 0x06, 0x08, 0x2a,
+        0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x03, 0x49, 0x00, 0x30, 0x46,
+        0x02, 0x21, 0x00, 0xe7, 0x1b, 0x44, 0x09, 0x19, 0x6d, 0xe4, 0xab, 0x53,
+        0xc8, 0xf0, 0x40, 0x29, 0xe3, 0x45, 0x2e, 0xeb, 0x6e, 0xb5, 0xf9, 0x60,
+        0x97, 0xc2, 0x8f, 0xfb, 0xcc, 0xcb, 0xca, 0x17, 0x78, 0x46, 0xfd, 0x02,
+        0x21, 0x00, 0xa8, 0x3e, 0xd2, 0xcd, 0xee, 0x78, 0xa6, 0x19, 0xd0, 0xe9,
+        0x52, 0x96, 0x76, 0xca, 0x42, 0x68, 0x43, 0x57, 0x89, 0x9e, 0x07, 0xae,
+        0x80, 0x75, 0x89, 0x8e, 0xcd, 0x8d, 0x52, 0x5e, 0x1f, 0x4e
+    };
+
+    ReturnErrorOnFailure(CopySpanToMutableSpan(ByteSpan(Dac_Cert_Array), outBuffer));
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductAttestationIntermediateCert(MutableByteSpan & outBuffer)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getPaiCert(outBuffer.data(), outBuffer.size());
+    if (len > 0)
+    {
+        outBuffer.reduce_size(len);
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    static const uint8_t Pai_Cert_Array[] = {
+        0x30, 0x82, 0x02, 0x0e, 0x30, 0x82, 0x01, 0xb4, 0xa0, 0x03, 0x02, 0x01,
+        0x02, 0x02, 0x08, 0x45, 0x9a, 0xf4, 0xcf, 0x2a, 0x66, 0x2a, 0x9d, 0x30,
+        0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x30,
+        0x4e, 0x31, 0x25, 0x30, 0x23, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x1c,
+        0x54, 0x72, 0x75, 0x73, 0x74, 0x41, 0x73, 0x69, 0x61, 0x20, 0x4d, 0x61,
+        0x74, 0x74, 0x65, 0x72, 0x20, 0x54, 0x65, 0x73, 0x74, 0x20, 0x50, 0x41,
+        0x41, 0x20, 0x56, 0x31, 0x31, 0x25, 0x30, 0x23, 0x06, 0x03, 0x55, 0x04,
+        0x0a, 0x0c, 0x1c, 0x54, 0x72, 0x75, 0x73, 0x74, 0x41, 0x73, 0x69, 0x61,
+        0x20, 0x54, 0x65, 0x63, 0x68, 0x6e, 0x6f, 0x6c, 0x6f, 0x67, 0x69, 0x65,
+        0x73, 0x2c, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x30, 0x20, 0x17, 0x0d, 0x32,
+        0x35, 0x30, 0x38, 0x32, 0x38, 0x30, 0x39, 0x31, 0x37, 0x31, 0x35, 0x5a,
+        0x18, 0x0f, 0x32, 0x30, 0x35, 0x35, 0x30, 0x38, 0x32, 0x31, 0x30, 0x39,
+        0x31, 0x37, 0x31, 0x35, 0x5a, 0x30, 0x62, 0x31, 0x21, 0x30, 0x1f, 0x06,
+        0x03, 0x55, 0x04, 0x03, 0x0c, 0x18, 0x53, 0x65, 0x6e, 0x73, 0x63, 0x6f,
+        0x6d, 0x6d, 0x20, 0x4d, 0x61, 0x74, 0x74, 0x65, 0x72, 0x20, 0x54, 0x65,
+        0x73, 0x74, 0x20, 0x50, 0x41, 0x49, 0x31, 0x27, 0x30, 0x25, 0x06, 0x03,
+        0x55, 0x04, 0x0a, 0x0c, 0x1e, 0x53, 0x65, 0x6e, 0x73, 0x63, 0x6f, 0x6d,
+        0x6d, 0x20, 0x53, 0x65, 0x6d, 0x69, 0x63, 0x6f, 0x6e, 0x64, 0x75, 0x63,
+        0x74, 0x6f, 0x72, 0x20, 0x43, 0x6f, 0x2e, 0x2c, 0x4c, 0x54, 0x44, 0x31,
+        0x14, 0x30, 0x12, 0x06, 0x0a, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0xa2,
+        0x7c, 0x02, 0x01, 0x0c, 0x04, 0x31, 0x35, 0x46, 0x45, 0x30, 0x59, 0x30,
+        0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08,
+        0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04,
+        0x50, 0x48, 0xfb, 0xaa, 0xd8, 0x44, 0xff, 0xf9, 0x6a, 0x1d, 0xb2, 0xf9,
+        0xb6, 0x90, 0xaa, 0x08, 0xe5, 0xa0, 0xe9, 0x94, 0x69, 0xe5, 0x9f, 0x9e,
+        0xcf, 0xb4, 0x1c, 0xb7, 0xbe, 0xab, 0x91, 0x3e, 0xd2, 0x7e, 0xa5, 0x79,
+        0x9c, 0xbe, 0x6f, 0x42, 0x13, 0xec, 0x1d, 0x46, 0x7f, 0x70, 0x9f, 0xd7,
+        0xb5, 0x46, 0x97, 0xaf, 0xe9, 0x2d, 0xcc, 0x42, 0xc6, 0x65, 0xf0, 0xa1,
+        0x85, 0x2b, 0xcb, 0x18, 0xa3, 0x66, 0x30, 0x64, 0x30, 0x12, 0x06, 0x03,
+        0x55, 0x1d, 0x13, 0x01, 0x01, 0xff, 0x04, 0x08, 0x30, 0x06, 0x01, 0x01,
+        0xff, 0x02, 0x01, 0x00, 0x30, 0x0e, 0x06, 0x03, 0x55, 0x1d, 0x0f, 0x01,
+        0x01, 0xff, 0x04, 0x04, 0x03, 0x02, 0x01, 0x06, 0x30, 0x1d, 0x06, 0x03,
+        0x55, 0x1d, 0x0e, 0x04, 0x16, 0x04, 0x14, 0x3d, 0xdf, 0x69, 0xee, 0x65,
+        0x11, 0xd2, 0x0f, 0x7d, 0x55, 0x23, 0xb9, 0x9d, 0xf8, 0xb2, 0x29, 0x19,
+        0x50, 0xa8, 0x14, 0x30, 0x1f, 0x06, 0x03, 0x55, 0x1d, 0x23, 0x04, 0x18,
+        0x30, 0x16, 0x80, 0x14, 0x32, 0x33, 0xb5, 0x85, 0x54, 0x86, 0xfe, 0x13,
+        0x73, 0x6d, 0x24, 0x0c, 0x97, 0x83, 0xba, 0xde, 0xf1, 0x93, 0x14, 0x28,
+        0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02,
+        0x03, 0x48, 0x00, 0x30, 0x45, 0x02, 0x20, 0x02, 0xf8, 0xd0, 0x6d, 0x14,
+        0xdc, 0x97, 0x40, 0x5d, 0xf4, 0x61, 0x28, 0xff, 0x3f, 0x2e, 0x87, 0xca,
+        0x8d, 0x5c, 0xf1, 0xb1, 0x09, 0x3c, 0x90, 0xb7, 0xaa, 0x86, 0x0e, 0xc9,
+        0xa5, 0x32, 0x2a, 0x02, 0x21, 0x00, 0xce, 0x25, 0xef, 0x37, 0x69, 0x5e,
+        0x32, 0x2c, 0x5a, 0xda, 0xda, 0x91, 0x96, 0x7c, 0xa5, 0x96, 0x7f, 0x00,
+        0x80, 0xf3, 0xb9, 0x40, 0x2c, 0x56, 0x73, 0xf1, 0x49, 0x24, 0xa4, 0x8d,
+        0x80, 0x95
+    };
+
+    ReturnErrorOnFailure(CopySpanToMutableSpan(ByteSpan(Pai_Cert_Array), outBuffer));
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::SignWithDeviceAttestationKey(const ByteSpan & messageToSign, MutableByteSpan & outSignBuffer)
+{
+    Crypto::P256ECDSASignature signature;
+    Crypto::P256Keypair keypair;
+    chip::Crypto::P256PublicKey dacPublicKey;
+
+    if (outSignBuffer.size() < signature.Capacity())
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
+
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+
+    uint32_t dacCertSize = 0, dacPrivateKeySize = 0;
+    uint8_t * pDacCertPtr       = mfd_getDacCertPtr(&dacCertSize);
+    uint8_t * pDacPrivateKeyPtr = mfd_getDacPrivateKeyPtr(&dacPrivateKeySize);
+
+    if (NULL == pDacCertPtr || 0 == dacCertSize || NULL == pDacPrivateKeyPtr || 0 == dacPrivateKeySize)
+    {
+        outSignBuffer.reduce_size(0);
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    ByteSpan dacCert(pDacCertPtr, dacCertSize);
+    ByteSpan dacPrivateKey(pDacPrivateKeyPtr, dacPrivateKeySize);
+
+#else
+    static const uint8_t Dac_PrivateKey_Array[] = { 0x03, 0xff, 0x59, 0xb9, 0x11, 0xdf, 0xe6, 0xc9, 0x7b, 0x17, 0x29, 0x71,
+                                                    0x17, 0x40, 0xec, 0x00, 0x36, 0x39, 0xd9, 0x06, 0xdd, 0xe5, 0x6b, 0x6e,
+                                                    0x59, 0x2c, 0x61, 0xeb, 0x43, 0x87, 0x40, 0x3c};
+
+    uint8_t dac_cert_array[Credentials::kMaxDERCertLength];
+    uint8_t dac_cert_private_key_array[sizeof(Dac_PrivateKey_Array)];
+    MutableByteSpan dacCert(dac_cert_array, Credentials::kMaxDERCertLength),
+        dacPrivateKey(dac_cert_private_key_array, sizeof(dac_cert_private_key_array));
+
+    ReturnErrorOnFailure(CopySpanToMutableSpan(ByteSpan(Dac_PrivateKey_Array), dacPrivateKey));
+    ReturnErrorOnFailure(GetDeviceAttestationCert(dacCert));
+
+#endif
+
+    ReturnErrorOnFailure(chip::Crypto::ExtractPubkeyFromX509Cert(dacCert, dacPublicKey));
+
+    ReturnErrorOnFailure(LoadKeypairFromRaw(dacPrivateKey, ByteSpan(dacPublicKey.Bytes(), dacPublicKey.Length()), keypair));
+    ReturnErrorOnFailure(keypair.ECDSA_sign_msg(messageToSign.data(), messageToSign.size(), signature));
+
+    ReturnErrorOnFailure(CopySpanToMutableSpan(ByteSpan(signature.Bytes(), signature.Length()), outSignBuffer));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR FactoryDataProvider::GetSetupDiscriminator(uint16_t & setupDiscriminator)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getDiscriminator((uint8_t *) &setupDiscriminator, sizeof(setupDiscriminator));
+    if (len > 0)
+    {
+        setupDiscriminator = 0xfff & setupDiscriminator;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    setupDiscriminator = 3840;
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::SetSetupDiscriminator(uint16_t setupDiscriminator)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR FactoryDataProvider::GetSpake2pIterationCount(uint32_t & iterationCount)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getSapke2It((uint8_t *) &iterationCount, sizeof(iterationCount));
+    if (len > 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    iterationCount = 1000;
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetSpake2pSalt(MutableByteSpan & saltBuf)
+{
+    static constexpr size_t kSpake2pSalt_MaxBase64Len = BASE64_ENCODED_LEN(chip::Crypto::kSpake2p_Max_PBKDF_Salt_Length) + 1;
+
+    CHIP_ERROR err                          = CHIP_ERROR_NOT_FOUND;
+    char saltB64[kSpake2pSalt_MaxBase64Len] = { 0 };
+    size_t saltB64Len                       = 0;
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getSapke2Salt(saltBuf.data(), saltBuf.size());
+    if (len > 0)
+    {
+        saltBuf.reduce_size(len);
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    size_t saltLen = chip::Base64Decode32(saltB64, saltB64Len, reinterpret_cast<uint8_t *>(saltB64));
+
+    ReturnErrorCodeIf(saltLen > saltBuf.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(saltBuf.data(), saltB64, saltLen);
+    saltBuf.reduce_size(saltLen);
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetSpake2pVerifier(MutableByteSpan & verifierBuf, size_t & verifierLen)
+{
+    static constexpr size_t kSpake2pSerializedVerifier_MaxBase64Len =
+        BASE64_ENCODED_LEN(chip::Crypto::kSpake2p_VerifierSerialized_Length) + 1;
+
+    CHIP_ERROR err                                            = CHIP_ERROR_NOT_FOUND;
+    char verifierB64[kSpake2pSerializedVerifier_MaxBase64Len] = { 0 };
+    size_t verifierB64Len                                     = 0;
+
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getSapke2Verifier(verifierBuf.data(), verifierBuf.size());
+    if (len > 0)
+    {
+        verifierLen = len;
+        verifierBuf.reduce_size(len);
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    verifierLen = chip::Base64Decode32(verifierB64, verifierB64Len, reinterpret_cast<uint8_t *>(verifierB64));
+    ReturnErrorCodeIf(verifierLen > verifierBuf.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+    memcpy(verifierBuf.data(), verifierB64, verifierLen);
+    verifierBuf.reduce_size(verifierLen);
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetSetupPasscode(uint32_t & setupPasscode)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getPasscode((uint8_t *) &setupPasscode, sizeof(setupPasscode));
+    if (len > 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    setupPasscode = 20202021;
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::SetSetupPasscode(uint32_t setupPasscode)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR FactoryDataProvider::GetVendorName(char * buf, size_t bufSize)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getVendorName(buf, bufSize);
+    if (len > 0)
+    {
+        buf[len] = 0;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    static const char vendorName[] = "Senscomm";
+    strncpy(buf, vendorName, bufSize);
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetVendorId(uint16_t & vendorId)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getVendorId((uint8_t *) &vendorId, sizeof(vendorId));
+    if (len > 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    vendorId = 0x15FE;
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductName(char * buf, size_t bufSize)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getProductName(buf, bufSize);
+    if (len > 0)
+    {
+        buf[len] = 0;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductId(uint16_t & productId)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getProductId((uint8_t *) &productId, sizeof(productId));
+    if (len > 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    productId = 0x1612;
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetPartNumber(char * buf, size_t bufSize)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getPartNumber(buf, bufSize);
+    if (len > 0)
+    {
+        buf[len] = 0;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductURL(char * buf, size_t bufSize)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getProductUrl(buf, bufSize);
+    if (len > 0)
+    {
+        buf[len] = 0;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductLabel(char * buf, size_t bufSize)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getProductLabel(buf, bufSize);
+    if (len > 0)
+    {
+        buf[len] = 0;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getSerialNumber(buf, bufSize);
+    if (len > 0)
+    {
+        buf[len] = 0;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    strncpy(buf, CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER, bufSize);
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day)
+{
+#define OS_YEAR                                                                                                                    \
+    ((((int) (__DATE__[7] - '0') * 10 + (int) (__DATE__[8] - '0')) * 10 + (int) (__DATE__[9] - '0')) * 10 +                        \
+     (int) (__DATE__[10] - '0'))
+
+#define OS_MONTH                                                                                                                   \
+    (__DATE__[2] == 'n'       ? (__DATE__[1] == 'a' ? 1 : 6)                                                                       \
+         : __DATE__[2] == 'b' ? 2                                                                                                  \
+         : __DATE__[2] == 'r' ? (__DATE__[0] == 'M' ? 3 : 4)                                                                       \
+         : __DATE__[2] == 'y' ? 5                                                                                                  \
+         : __DATE__[2] == 'l' ? 7                                                                                                  \
+         : __DATE__[2] == 'g' ? 8                                                                                                  \
+         : __DATE__[2] == 'p' ? 9                                                                                                  \
+         : __DATE__[2] == 't' ? 10                                                                                                 \
+         : __DATE__[2] == 'v' ? 11                                                                                                 \
+                              : 12)
+
+#define OS_DAY ((__DATE__[4] == ' ' ? 0 : __DATE__[4] - '0') * 10 + (__DATE__[5] - '0'))
+
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    if (mfd_getManufacturingDate(&year, &month, &day))
+    {
+        return CHIP_NO_ERROR;
+    }
+#endif
+
+    year  = (uint16_t) OS_YEAR;
+    month = (uint8_t) OS_MONTH;
+    day   = (uint8_t) OS_DAY;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR FactoryDataProvider::GetHardwareVersion(uint16_t & hardwareVersion)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getHardwareVersion((uint8_t *) &hardwareVersion, sizeof(hardwareVersion));
+    if (len > 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    hardwareVersion = CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION;
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetHardwareVersionString(char * buf, size_t bufSize)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+    len     = mfd_getHardwareVersionString(buf, bufSize);
+    if (len > 0)
+    {
+        buf[len] = 0;
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    strncpy(buf, CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION_STRING, bufSize);
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+CHIP_ERROR FactoryDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan)
+{
+#if CONFIG_SENSCOMM_FACTORY_DATA_ENABLE
+    int len = 0;
+
+    len = mfd_getRotatingDeviceIdUniqueId(uniqueIdSpan.data(), uniqueIdSpan.size());
+    if (len > 0)
+    {
+        return CHIP_NO_ERROR;
+    }
+    else if (0 == len)
+    {
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    return CHIP_ERROR_BUFFER_TOO_SMALL;
+#else
+    constexpr uint8_t uniqueId[] = CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID;
+
+    VerifyOrReturnValue(uniqueIdSpan.size() >= sizeof(uniqueId), CHIP_ERROR_INVALID_ARGUMENT);
+
+    memcpy(uniqueIdSpan.data(), uniqueId, sizeof(uniqueId));
+    uniqueIdSpan.reduce_size(sizeof(uniqueId));
+
+    return CHIP_NO_ERROR;
+#endif
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/senscomm/scm1612s/FactoryDataProvider.h
+++ b/src/platform/senscomm/scm1612s/FactoryDataProvider.h
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <platform/CommissionableDataProvider.h>
+#include <platform/DeviceInstanceInfoProvider.h>
+
+#include <system/SystemError.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class FactoryDataProvider : public chip::Credentials::DeviceAttestationCredentialsProvider,
+                            public CommissionableDataProvider,
+                            public DeviceInstanceInfoProvider
+{
+public:
+    CHIP_ERROR Init();
+
+    // ===== Members functions that implement the DeviceAttestationCredentialsProvider
+    CHIP_ERROR GetCertificationDeclaration(MutableByteSpan & outBuffer) override;
+    CHIP_ERROR GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer) override;
+    CHIP_ERROR GetDeviceAttestationCert(MutableByteSpan & outBuffer) override;
+    CHIP_ERROR GetProductAttestationIntermediateCert(MutableByteSpan & outBuffer) override;
+    CHIP_ERROR SignWithDeviceAttestationKey(const ByteSpan & messageToSign, MutableByteSpan & outSignBuffer) override;
+
+    // ===== Members functions that implement the CommissionableDataProvider
+    CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) override;
+    CHIP_ERROR SetSetupDiscriminator(uint16_t setupDiscriminator) override;
+    CHIP_ERROR GetSpake2pIterationCount(uint32_t & iterationCount) override;
+    CHIP_ERROR GetSpake2pSalt(MutableByteSpan & saltBuf) override;
+    CHIP_ERROR GetSpake2pVerifier(MutableByteSpan & verifierBuf, size_t & verifierLen) override;
+    CHIP_ERROR GetSetupPasscode(uint32_t & setupPasscode) override;
+    CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override;
+
+    // ===== Members functions that implement the DeviceInstanceInfoProvider
+    CHIP_ERROR GetVendorName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
+    CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
+    CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;
+    CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/senscomm/scm1612s/args.gni
+++ b/src/platform/senscomm/scm1612s/args.gni
@@ -40,6 +40,8 @@ chip_enable_ota_requestor = true
 
 #chip_stack_lock_tracking = "none"
 
+chip_build_example_creds = false
+
 custom_toolchain = "${chip_root}/config/senscomm/toolchain:senscomm"
 
 is_debug = false


### PR DESCRIPTION
New features:

Changes:
- Use our own VID/PID instead of test ones
- Use our own factory DAC/PAI.. instead of test ones

Fixs:

Issues:
- Senscomm/wise/issues/2896

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

