### PR TITLE
[BUILD] Increase FS size to 512KB for Matter certification

### DIFF
--- a/third_party/senscomm/scm1612s/scm1612s_executable.gni
+++ b/third_party/senscomm/scm1612s/scm1612s_executable.gni
@@ -54,7 +54,7 @@ template("scm1612s_postbuild") {
       "--align", "4",
       "--version", "0.1",
       "--header-size", "0x20",
-      "--slot-size", "0x1d4000",
+      "--slot-size", "0x1b4000",
       "--pad-header",
       rebase_path("${root_out_dir}/${original_image_name}", root_build_dir),
       rebase_path("${root_out_dir}/${mcuboot_image_name}", root_build_dir),


### PR DESCRIPTION
New features:

Changes:

- Support larger FS to support Matter certification especially when there are multiple device types defined over multiple Endpoints because some TCs require larger number of files to be created.

Fixes:

Issues:

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

